### PR TITLE
add chrome support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,46 @@
-# PolymarketOddsConverter
-Extension to automatically convert Polymarket odds to decimal.
+# Polymarket Odds Converter
 
-![image](https://github.com/user-attachments/assets/f74809ba-8662-4421-93d6-ba12e2b4c7c2)
+A browser extension that converts Polymarket implied probabilities to decimal odds. Works on both Chrome and Firefox.
+
+## Features
+
+- Converts Polymarket probabilities to decimal odds
+- Toggle extension on/off with a single click
+- Works on all Polymarket pages
+- Supports both Chrome and Firefox
+
+## Installation
+
+### Chrome
+
+1. Download or clone this repository
+2. Open Chrome and go to `chrome://extensions/`
+3. Enable "Developer mode" in the top right
+4. Click "Load unpacked"
+5. Select the extension directory
+6. Make sure to use `manifest-chrome.json` as the manifest file by renaming to `manifest.json`
+
+### Firefox
+
+1. Download or clone this repository
+2. Open Firefox and go to `about:debugging#/runtime/this-firefox`
+3. Click "Load Temporary Add-on"
+4. Select the extension directory
+5. Make sure to use `manifest-firefox.json` as the manifest file by renaming to `manifest.json`
+
+## Usage
+
+1. Navigate to any Polymarket page
+2. The extension will automatically convert probabilities to decimal odds
+3. Click the extension icon in your browser toolbar to toggle the conversion on/off
+
+## Development
+
+The extension uses different manifest files for Chrome and Firefox due to browser-specific requirements:
+
+- `manifest-chrome.json`: Uses service worker for Chrome
+- `manifest-firefox.json`: Uses background scripts for Firefox
+
+For reference on this issue, see:
+https://stackoverflow.com/questions/75043889/manifest-v3-background-scripts-service-worker-on-firefox
+https://github.com/w3c/webextensions/issues/282

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A browser extension that converts Polymarket implied probabilities to decimal odds. Works on both Chrome and Firefox.
 
+![image](https://github.com/user-attachments/assets/f74809ba-8662-4421-93d6-ba12e2b4c7c2)
+
 ## Features
 
 - Converts Polymarket probabilities to decimal odds

--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ The extension uses different manifest files for Chrome and Firefox due to browse
 - `manifest-firefox.json`: Uses background scripts for Firefox
 
 For reference on this issue, see:
-https://stackoverflow.com/questions/75043889/manifest-v3-background-scripts-service-worker-on-firefox
-https://github.com/w3c/webextensions/issues/282
+- https://stackoverflow.com/questions/75043889/manifest-v3-background-scripts-service-worker-on-firefox
+- https://github.com/w3c/webextensions/issues/282

--- a/background.js
+++ b/background.js
@@ -2,23 +2,24 @@
 let isEnabled = true;
 
 // Handle toolbar icon clicks
-browser.browserAction.onClicked.addListener(() => {
+chrome.action.onClicked.addListener(() => {
   isEnabled = !isEnabled;
 
   // Update icon title
-  browser.browserAction.setTitle({
+  chrome.action.setTitle({
     title: `Odds Converter: ${isEnabled ? "ON" : "OFF"}`,
   });
 
   // Send message to content script
-  browser.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    browser.tabs.sendMessage(tabs[0].id, { isEnabled });
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    chrome.tabs.sendMessage(tabs[0].id, { isEnabled });
   });
 });
 
 // Respond to content script checking enabled state
-browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === "getState") {
     sendResponse({ isEnabled });
   }
+  return true; // Required for Chrome's async sendResponse
 });

--- a/content.js
+++ b/content.js
@@ -110,7 +110,7 @@ function setupObserver() {
 }
 
 // Listen for messages from background script
-browser.runtime.onMessage.addListener((message) => {
+chrome.runtime.onMessage.addListener((message) => {
   isEnabled = message.isEnabled;
   if (isEnabled) {
     updatePrices();
@@ -120,7 +120,7 @@ browser.runtime.onMessage.addListener((message) => {
 });
 
 // Check initial state
-browser.runtime.sendMessage({ action: "getState" }, (response) => {
+chrome.runtime.sendMessage({ action: "getState" }, (response) => {
   isEnabled = response.isEnabled;
   if (isEnabled) {
     updatePrices();

--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -1,0 +1,28 @@
+{
+    "manifest_version": 3,
+    "name": "Polymarket Odds Converter",
+    "version": "1.0",
+    "description": "Converts Polymarket implied probabilities to decimal odds",
+    "icons": {
+      "16": "icons/favicon.png",
+      "48": "icons/favicon.png",
+      "128": "icons/favicon.png"
+    },
+    "action": {
+      "default_icon": {
+        "48": "icons/favicon.png"
+      },
+      "default_title": "Odds Converter: ON"
+    },
+    "permissions": ["storage"],
+    "host_permissions": ["*://*.polymarket.com/*"],
+    "content_scripts": [
+      {
+        "matches": ["*://*.polymarket.com/*"],
+        "js": ["content.js"]
+      }
+    ],
+    "background": {
+      "service_worker": "background.js"
+    }
+} 

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -1,0 +1,28 @@
+{
+    "manifest_version": 3,
+    "name": "Polymarket Odds Converter",
+    "version": "1.0",
+    "description": "Converts Polymarket implied probabilities to decimal odds",
+    "icons": {
+      "16": "icons/favicon.png",
+      "48": "icons/favicon.png",
+      "128": "icons/favicon.png"
+    },
+    "action": {
+      "default_icon": {
+        "48": "icons/favicon.png"
+      },
+      "default_title": "Odds Converter: ON"
+    },
+    "permissions": ["storage"],
+    "host_permissions": ["*://*.polymarket.com/*"],
+    "content_scripts": [
+      {
+        "matches": ["*://*.polymarket.com/*"],
+        "js": ["content.js"]
+      }
+    ],
+    "background": {
+      "scripts": ["background.js"]
+    }
+} 


### PR DESCRIPTION
Currently, Firefox continues to use scripts and Google Chrome continues to use service_worker.
Given that chrome outputs an error in Developer mode `'background.scripts' requires manifest version of 2 or lower.`, I decided to use two separate manifest.json files.

For reference:
- https://github.com/w3c/webextensions/issues/282#issuecomment-2723981421
- https://stackoverflow.com/questions/75043889/manifest-v3-background-scripts-service-worker-on-firefox